### PR TITLE
Remove date setup from setupTests and remove intl package

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "eslint-plugin-prettier": "^3.1.1",
     "govuk-frontend": "^3.6.0",
     "identity-obj-proxy": "^3.0.0",
-    "intl": "^1.2.5",
     "jest": "^25.5.4",
     "jest-fetch-mock": "^3.0.3",
     "mockdate": "^3.0.2",

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,18 +1,1 @@
-import IntlPolyfill from 'intl';
-import 'intl/locale-data/jsonp/en-GB';
 import '@testing-library/jest-dom/extend-expect';
-
-global.console = {
-  log: jest.fn(), // console.log are ignored in tests
-  error: console.error,
-  warn: console.warn,
-  info: console.info,
-  debug: console.debug
-};
-
-if (global.Intl) {
-  Intl.NumberFormat = IntlPolyfill.NumberFormat;
-  Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
-} else {
-  global.Intl = IntlPolyfill;
-}

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom/extend-expect';
+
+global.console = {
+  log: jest.fn(), // console.log are ignored in tests
+  error: console.error,
+  warn: console.warn,
+  info: console.info,
+  debug: console.debug
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6767,11 +6767,6 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-intl@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
-  integrity sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94=
-
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"


### PR DESCRIPTION
**What**  
Remove date setup from setupTests and remove intl package

**Why**  
We don't seem to need it as moment is used to format the date
