### PR TITLE
Add basic snapshot summary page

### DIFF
--- a/components/Feature/VulnerabilitiesGrid/index.js
+++ b/components/Feature/VulnerabilitiesGrid/index.js
@@ -31,7 +31,7 @@ const VulnerabilitiesGrid = ({ onUpdate }) => {
   };
 
   return (
-    <Accordion>
+    <Accordion title="Things to explore with the resident">
       {groups.map(({ id, name, assets, vulnerabilities }, i) => (
         <AccordionItem key={`${id}-${i}`} id={`${id}-${i}`} heading={name}>
           <div className="govuk-grid-row">

--- a/components/Form/Accordion/index.js
+++ b/components/Form/Accordion/index.js
@@ -1,5 +1,12 @@
-const Accordion = ({ children }) => (
+import styles from './index.module.scss';
+
+const Accordion = ({ children, title }) => (
   <div className="govuk-accordion" data-module="govuk-accordion">
+    <div
+      className={`govuk-accordion__controls ${styles['lbh-accordion__controls']}`}
+    >
+      <div>{title && <h2>{title}</h2>}</div>
+    </div>
     {children}
   </div>
 );

--- a/components/Form/Accordion/index.module.scss
+++ b/components/Form/Accordion/index.module.scss
@@ -1,0 +1,4 @@
+.lbh-accordion__controls {
+  display: flex;
+  justify-content: space-between;
+}

--- a/components/Form/Accordion/index.test.js
+++ b/components/Form/Accordion/index.test.js
@@ -3,7 +3,8 @@ import Accordion from './index';
 
 describe('Accordion', () => {
   it('renders a accordion', () => {
-    const { container } = render(<Accordion />);
+    const { container, getByText } = render(<Accordion title="my acc" />);
     expect(container.querySelector('.govuk-accordion')).toBeInTheDocument();
+    expect(getByText('my acc')).toBeInTheDocument();
   });
 });

--- a/components/Form/AccordionItem/index.js
+++ b/components/Form/AccordionItem/index.js
@@ -1,6 +1,10 @@
+import styles from './index.module.scss';
+
 const AccordionItem = ({ children, heading, id }) => (
   <div className="govuk-accordion__section">
-    <div className="govuk-accordion__section-header">
+    <div
+      className={`govuk-accordion__section-header ${styles['lbh-accordion__section-header']}`}
+    >
       <h3 className="govuk-accordion__section-heading">
         <span className="govuk-accordion__section-button" id={id}>
           {heading}

--- a/components/Form/AccordionItem/index.module.scss
+++ b/components/Form/AccordionItem/index.module.scss
@@ -1,0 +1,5 @@
+@import '../../../pages/stylesheets/vars.scss';
+
+.lbh-accordion__section-header {
+  color: $hackney-green !important;
+}

--- a/lib/api/utils/useSnapshot.js
+++ b/lib/api/utils/useSnapshot.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import useSWR from 'swr';
-import { requestSnapshot } from 'lib/api';
+import { requestSnapshot, requestUpdateSnapshot } from 'lib/api';
 
 export default function useSnapshot(
   snapshotId,
@@ -29,6 +29,10 @@ export default function useSnapshot(
   return {
     snapshot: data,
     error,
-    loading: data === null
+    loading: data === null,
+    updateSnapshot: withErrorHandling(async snapshot => {
+      await requestUpdateSnapshot(snapshot, { token });
+      mutate({ ...data, snapshot });
+    })
   };
 }

--- a/pages/api/snapshots/[id]/index.test.js
+++ b/pages/api/snapshots/[id]/index.test.js
@@ -58,6 +58,7 @@ describe('Get/Update Snapshot Api', () => {
       });
       expect(updateSnapshot.execute).toHaveBeenCalledWith({ snapshot });
       expect(response.statusCode).toBe(204);
+      expect(response.body).toBeUndefined();
     });
 
     it('accepts PATCH requests', async () => {

--- a/pages/snapshots/[id].test.js
+++ b/pages/snapshots/[id].test.js
@@ -30,7 +30,9 @@ describe('SnapshotSummary', () => {
     it('shows the name', () => {
       const snapshot = {
         firstName: 'John',
-        lastName: 'Wick'
+        lastName: 'Wick',
+        vulnerabilities: [],
+        assets: []
       };
       const { getByText } = render(
         <SnapshotSummary initialSnapshot={snapshot} />
@@ -41,17 +43,70 @@ describe('SnapshotSummary', () => {
     });
 
     it('shows the vulnerabilities grid', () => {
-      const { container } = render(<SnapshotSummary initialSnapshot={{}} />);
+      const snapshot = {
+        vulnerabilities: [],
+        assets: []
+      };
+      const { container } = render(
+        <SnapshotSummary initialSnapshot={snapshot} />
+      );
       expect(container.querySelector('.govuk-accordion')).toBeInTheDocument();
     });
 
     it('shows the notes', () => {
+      const snapshot = {
+        vulnerabilities: [],
+        assets: []
+      };
       const { getByLabelText } = render(
-        <SnapshotSummary initialSnapshot={{}} />
+        <SnapshotSummary initialSnapshot={snapshot} />
       );
       expect(
         getByLabelText(`Any other notes you'd like to add?`)
       ).toBeInTheDocument();
+    });
+
+    it('hides the edit view if a vulnerability exists', () => {
+      const snapshot = {
+        vulnerabilities: ['v1'],
+        assets: []
+      };
+      const { container, getByText } = render(
+        <SnapshotSummary initialSnapshot={snapshot} />
+      );
+      expect(
+        container.querySelector('.govuk-accordion')
+      ).not.toBeInTheDocument();
+      expect(getByText('v1')).toBeInTheDocument();
+    });
+
+    it('hides the edit view if a asset exists', () => {
+      const snapshot = {
+        vulnerabilities: [],
+        assets: ['a1']
+      };
+      const { container, getByText } = render(
+        <SnapshotSummary initialSnapshot={snapshot} />
+      );
+      expect(
+        container.querySelector('.govuk-accordion')
+      ).not.toBeInTheDocument();
+      expect(getByText('a1')).toBeInTheDocument();
+    });
+
+    it('hides the edit view if notes exist', () => {
+      const snapshot = {
+        vulnerabilities: [],
+        assets: [],
+        notes: 'some notes'
+      };
+      const { container, getByText } = render(
+        <SnapshotSummary initialSnapshot={snapshot} />
+      );
+      expect(
+        container.querySelector('.govuk-accordion')
+      ).not.toBeInTheDocument();
+      expect(getByText('some notes')).toBeInTheDocument();
     });
   });
 });

--- a/pages/stylesheets/gov-uk-overrides.scss
+++ b/pages/stylesheets/gov-uk-overrides.scss
@@ -5,3 +5,7 @@
 .govuk-tag {
   background-color: $hackney-green;
 }
+
+.govuk-accordion__open-all {
+  color: $hackney-green !important;
+}

--- a/public/js/govuk.js
+++ b/public/js/govuk.js
@@ -819,10 +819,13 @@ Accordion.prototype.initControls = function () {
   this.$openAllButton.setAttribute('type', 'button');
 
   // Create control wrapper and add controls to it
-  var accordionControls = document.createElement('div');
-  accordionControls.setAttribute('class', this.controlsClass);
+  // var accordionControls = document.createElement('div');
+  // accordionControls.setAttribute('class', this.controlsClass);
+  // accordionControls.appendChild(this.$openAllButton);
+  // this.$module.insertBefore(accordionControls, this.$module.firstChild);
+
+  var accordionControls = this.$module.querySelector('.' + this.controlsClass);
   accordionControls.appendChild(this.$openAllButton);
-  this.$module.insertBefore(accordionControls, this.$module.firstChild);
 
   // Handle events for the controls
   this.$openAllButton.addEventListener('click', this.onOpenOrCloseAllToggle.bind(this));


### PR DESCRIPTION
**What**  
Add a basic summary page

**Why**  
So we can see the details of a snapshot

<img width="793" alt="Screenshot 2020-06-22 at 10 26 31" src="https://user-images.githubusercontent.com/52740958/85271605-ec2f0f80-b472-11ea-96e9-1bc9e258938d.png">
