### PR TITLE
Hotfix: Decrypts secure SSM parameters when deploying

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -50,7 +50,7 @@ functions:
       VULNERABILITIES_TABLE_NAME: ${self:provider.environment.VULNERABILITIES_TABLE}
       NEXT_PUBLIC_API_URL: https://${self:custom.aliases.${self:provider.stage}}/api
       NEXT_PUBLIC_URL: https://${self:custom.aliases.${self:provider.stage}}
-      AIRTABLE_API_KEY: ${ssm:/vulnerabilities/airtable-api-key}
+      AIRTABLE_API_KEY: ${ssm:/vulnerabilities/airtable-api-key~true}
       AIRTABLE_BASE_ID: ${ssm:/vulnerabilities/airtable-base-id}
       AIRTABLE_TABLE_NAMES: ${ssm:/vulnerabilities/airtable-table-names}
 


### PR DESCRIPTION
**What**  
`AIRTABLE_API_KEY` is stored as a `SecureString` in SSM, by default these are not decrypted by Serverless - adding `~true` will decrypt them during deployment.

**Why**  
To fix calls to Airtable in staging and production.
