### PR TITLE
Rename "ttl" attribute to "expires"

### DIFF
--- a/lib/domain/snapshot.js
+++ b/lib/domain/snapshot.js
@@ -26,5 +26,5 @@ export default class Snapshot {
   }
 
   // dynamodb ttl
-  ttl;
+  expires;
 }

--- a/lib/gateways/snapshot-gateway.js
+++ b/lib/gateways/snapshot-gateway.js
@@ -22,7 +22,7 @@ class SnapshotGateway {
       systemIds
     });
 
-    snapshot.ttl = moment()
+    snapshot.expires = moment()
       .add(12, 'hours')
       .unix();
 
@@ -94,18 +94,18 @@ class SnapshotGateway {
     if (!snapshot) throw new ArgumentError('snapshot cannot be null.');
 
     // remove the dynamodb ttl on save
-    delete snapshot.ttl;
+    delete snapshot.expires;
 
     const updateExpression = [
       'set assets = :a',
       'vulnerabilities = :v',
-      'ttl = :t'
+      'expires = :e'
     ];
 
     const expressionAttributeValues = {
       ':a': snapshot.assets,
       ':v': snapshot.vulnerabilities,
-      ':t': snapshot.ttl
+      ':e': null
     };
 
     if (snapshot.notes) {

--- a/lib/gateways/snapshot-gateway.test.js
+++ b/lib/gateways/snapshot-gateway.test.js
@@ -77,7 +77,7 @@ describe('SnapshotGateway', () => {
         lastName: 'Nasty'
       });
 
-      expect(result.ttl).toEqual(then);
+      expect(result.expires).toEqual(then);
     });
   });
 
@@ -345,11 +345,12 @@ describe('SnapshotGateway', () => {
         UpdateExpression: [
           'set assets = :a',
           'vulnerabilities = :v',
-          'ttl = :t',
+          'expires = :e',
           'notes = :n'
         ].join(', '),
         ExpressionAttributeValues: {
           ':a': snapshot.assets,
+          ':e': null,
           ':v': snapshot.vulnerabilities,
           ':n': snapshot.notes
         },
@@ -370,12 +371,12 @@ describe('SnapshotGateway', () => {
         notes: '',
         vulnerabilities: ['a vulnerability']
       });
-      snapshot.ttl = 123;
+      snapshot.expires = 123;
       const snapshotGateway = new SnapshotGateway({ client, tableName });
 
       const result = await snapshotGateway.save({ snapshot });
 
-      expect(result.ttl).toBeUndefined();
+      expect(result.expires).toBeUndefined();
     });
 
     it('does not save notes when notes is empty', async () => {
@@ -392,10 +393,11 @@ describe('SnapshotGateway', () => {
         UpdateExpression: [
           'set assets = :a',
           'vulnerabilities = :v',
-          'ttl = :t'
+          'expires = :e'
         ].join(', '),
         ExpressionAttributeValues: {
           ':a': snapshot.assets,
+          ':e': null,
           ':v': snapshot.vulnerabilities
         },
         ReturnValues: 'UPDATED_NEW'

--- a/serverless.yml
+++ b/serverless.yml
@@ -99,7 +99,7 @@ resources:
                 - id
                 - systemIds
         TimeToLiveSpecification:
-          AttributeName: ttl
+          AttributeName: expires
           Enabled: true
 
     CloudFrontDistribution:


### PR DESCRIPTION
**What**  
Rename the "ttl" attribute to "expires" as ttl is a reserved word

**Why**  
Creating a record with "ttl" works, but patching a record with ttl doesn't (?!)
