### PR TITLE
Refactor _app and CookieBanner so that getInitialProps not reqd in _app

### DIFF
--- a/components/CookieBanner/index.js
+++ b/components/CookieBanner/index.js
@@ -9,8 +9,8 @@ const cookieNames = {
   optedIn: 'cookie_opt_in'
 };
 
-const CookieBanner = ({ cookies }) => {
-  const [cookieState, setCookieState] = useState('unread');
+const CookieBanner = () => {
+  const [cookieState, setCookieState] = useState('read');
 
   const deleteCookies = () => {
     document.cookie = '_ga= ; expires = Thu, 01 Jan 1970 00:00:00 GMT;';
@@ -51,17 +51,18 @@ const CookieBanner = ({ cookies }) => {
   });
 
   useEffect(() => {
+    const cookies = cookie.parse(document.cookie ?? {});
     const hasReadMessage = cookies[cookieNames.seen] === 'true';
     const hasCookieOptIn = cookies[cookieNames.optedIn] === 'true';
 
     if (hasReadMessage) {
-      setCookieState('read');
-
       if (hasCookieOptIn) {
         initTagManager();
       } else {
         deleteCookies();
       }
+    } else {
+      setCookieState('unread');
     }
   }, []);
 

--- a/components/Layout/index.js
+++ b/components/Layout/index.js
@@ -1,13 +1,12 @@
-import cookie from 'cookie';
 import CookieBanner from '../CookieBanner';
 import Footer from './Footer';
 import Header from './Header';
 import SkipLink from './SkipLink';
 import PhaseBanner from './PhaseBanner';
 
-const Layout = ({ children, cookies }) => (
+const Layout = ({ children }) => (
   <>
-    <CookieBanner cookies={cookies || cookie.parse(document.cookie)} />
+    <CookieBanner />
     <SkipLink />
     <Header serviceName="Vulnerabilities" />
     <div className="govuk-width-container app-width-container">

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,4 @@
 import App from 'next/app';
-import cookie from 'cookie';
 import Layout from 'components/Layout';
 import './stylesheets/all.scss';
 
@@ -9,10 +8,10 @@ export default class MyApp extends App {
   };
 
   render() {
-    const { Component, cookies, pageProps } = this.props;
+    const { Component, pageProps } = this.props;
     return (
       <>
-        <Layout cookies={cookies}>
+        <Layout>
           <Component {...pageProps} />
         </Layout>
         <script src="/js/govuk.js"></script>
@@ -20,9 +19,3 @@ export default class MyApp extends App {
     );
   }
 }
-
-MyApp.getInitialProps = async context => {
-  const baseProps = await App.getInitialProps(context);
-  const cookies = cookie.parse(context.ctx.req.headers.cookie ?? '');
-  return { cookies, ...baseProps };
-};

--- a/pages/snapshots/[id].test.js
+++ b/pages/snapshots/[id].test.js
@@ -138,6 +138,6 @@ describe('SnapshotSummary', () => {
         'href',
         'https://staging-singleview.hackney.gov.uk/customers/123/view'
       );
-    })
+    });
   });
 });


### PR DESCRIPTION
**What**  
Move the cookie stuff out of _app.js getInitialProps

**Why**  
Adding getInitialProps to _app.js means no more auto static pages in the next build, and we like static pages
