### PR TITLE
Fix accessibility warnings

### DIFF
--- a/components/Feature/VulnerabilitiesGrid/grid.json
+++ b/components/Feature/VulnerabilitiesGrid/grid.json
@@ -263,7 +263,7 @@
     ]
   },
   {
-    "id": "life-events and transitions",
+    "id": "life-events-and-transitions",
     "name": "Life events and transitions",
     "assets": [
       {

--- a/components/Layout/Header/index.js
+++ b/components/Layout/Header/index.js
@@ -3,27 +3,25 @@ import css from './index.module.scss';
 
 const Header = ({ serviceName }) => (
   <header className="govuk-header" role="banner" data-module="govuk-header">
-    <div
+    <a
+      href="/"
       className={`govuk-header__container govuk-width-container ${css['lbh-header__container']}`}
     >
       <div className="govuk-header__logo">
-        <a href="/" className="govuk-header__link govuk-header__link--homepage">
+        <div className="govuk-header__link govuk-header__link--homepage">
           <span
             className={`govuk-header__logotype ${css['lbh-header__logotype']}`}
           >
             <HackneyLogo />
           </span>
-        </a>
+        </div>
       </div>
       <div className="govuk-header__content">
-        <a
-          href="/"
-          className="govuk-header__link govuk-header__link--service-name"
-        >
+        <div className="govuk-header__link govuk-header__link--service-name">
           {serviceName}
-        </a>
+        </div>
       </div>
-    </div>
+    </a>
   </header>
 );
 

--- a/components/Layout/Header/index.module.scss
+++ b/components/Layout/Header/index.module.scss
@@ -1,6 +1,7 @@
 .lbh-header__container {
   display: flex;
   align-items: center;
+  color: white;
 }
 
 .lbh-header__logotype {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -5,6 +5,7 @@ export default class AppDocument extends Document {
     return (
       <Html className="govuk-template lbh-template" lang="en-gb">
         <Head>
+          <title>Snapshot</title>
           <script
             dangerouslySetInnerHTML={{
               __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src="https://www.googletagmanager.com/gtm.js?id="+i+dl;f.parentNode.insertBefore(j,f);})(window,document,"script","dataLayer","${process.env.NEXT_PUBLIC_GTM_ID}");`

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,7 +3,7 @@ import Document, { Html, Head, Main, NextScript } from 'next/document';
 export default class AppDocument extends Document {
   render() {
     return (
-      <Html className="govuk-template lbh-template">
+      <Html className="govuk-template lbh-template" lang="en-gb">
         <Head>
           <script
             dangerouslySetInnerHTML={{

--- a/pages/snapshots/[id].js
+++ b/pages/snapshots/[id].js
@@ -51,6 +51,7 @@ const SnapshotSummary = ({ resources, initialSnapshot, token }) => {
 
   return (
     <>
+      <title>Snapshot</title>
       <div>
         <a
           href={`${process.env.NEXT_PUBLIC_SINGLEVIEW_URL}/customers/${customerId}/view`}

--- a/pages/snapshots/[id].js
+++ b/pages/snapshots/[id].js
@@ -51,7 +51,6 @@ const SnapshotSummary = ({ resources, initialSnapshot, token }) => {
 
   return (
     <>
-      <title>Snapshot</title>
       <div>
         <a
           href={`${process.env.NEXT_PUBLIC_SINGLEVIEW_URL}/customers/${customerId}/view`}


### PR DESCRIPTION
**What**  
Fix accessibility warnings
<img width="617" alt="image" src="https://user-images.githubusercontent.com/54268893/89768482-8dd9f100-daf3-11ea-8888-8fde7fe30b4a.png">

Two no script warnings left. Not sure if we want to remove "noscript " tags
<img width="216" alt="image" src="https://user-images.githubusercontent.com/54268893/89768572-ab0ebf80-daf3-11ea-9d6a-be0ff77f5abc.png">


**Why**  
To make the tool more accessible
